### PR TITLE
Fixed Search Issue

### DIFF
--- a/WebContent/user/search.jsp
+++ b/WebContent/user/search.jsp
@@ -67,8 +67,8 @@
 				End Date: <input type="text" id="endDate" name="endDate" value="${endDate}"><br>
 				End Time: <input id="endTime" name="endTime" value="${tc.convertTimeTo12(endTime).trim()}"><br>
 				Reservation Length: ${hourIncrementSelect}<br><br>
-			</div>
 				<input align="center" class="btn btn-lg btn-red" name="makeReservation" type="submit" value="Search"> 
+			</div>
 			</form>
 		</div>
 		

--- a/src/controllers/UserSearchServlet.java
+++ b/src/controllers/UserSearchServlet.java
@@ -85,7 +85,7 @@ public class UserSearchServlet extends HttpServlet {
 				String startDate = startDateSlashed;
 				String endDate = endDateSlashed;
 				
-				// get the current date and current time
+				// get the current date and current hour block
 				String currentDate = dtc.parseDate(dtc.datetimeStamp());
 				String currentHourBlock = tc.currentHour() + ":00:00";
 				
@@ -163,13 +163,21 @@ public class UserSearchServlet extends HttpServlet {
 						ReservationSelectQuery res = new ReservationSelectQuery();
 						RoomsSelectQuery rsq = new RoomsSelectQuery();
 						
+						// check to make sure hour increment is not greater than user selected time range
+						List<String> timesCheck = tc.timeRangeList(startTime, endTime);
+						if (startDate.equals(endDate) && (timesCheck.size() -1) < Integer.parseInt(hourIncrement)){
+							hourIncrement = "1";
+						}
+						
 						// list for the room number.  Below will print all times, inclusive between start and end
 						List<String> roomNumber = rsq.roomList(Integer.parseInt(buildingID));
 						
+						// Array list for the user selected times
 						List<String> times = tc.timeRangeList(startTime, TimeConverter.subtractTime(endTime, Integer.parseInt(hourIncrement))); 
 						List<String> times2 = tc.timeRangeList(startTime, TimeConverter.subtractTime("00:00:00", Integer.parseInt(hourIncrement)));
 						List<String> times3 = tc.timeRangeList("00:00:00", TimeConverter.subtractTime("00:00:00", Integer.parseInt(hourIncrement)));
 						List<String> times4 = tc.timeRangeList("00:00:00", TimeConverter.subtractTime(endTime, Integer.parseInt(hourIncrement)));
+						
 						
 						// date range list.  Print all dates between start and end date inclusive
 						List<String> dates = dtc.dateRangeList(startDate, endDate);


### PR DESCRIPTION
— if the user selects a time range that’s one hour in length but sets
the reservation length to 2 hours, it will automatically change the
reservation length to 1. This only affects searches with the same start
date and end date.